### PR TITLE
Add `input` method

### DIFF
--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,0 +1,6 @@
+extern crate inquirer;
+
+fn main() {
+    let answer = inquirer::input("What is the airspeed velocity of an unladen swallow?");
+    println!("You answered: {:?}", answer);
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,46 @@
+use std::io::{Write, stdout, stdin};
+use termion::{TermRead, TermWrite, color};
+
+use error::Error;
+
+/// Prompt the user to input a string.
+///
+/// The return type is a `Result` that contains a `String`.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # extern crate inquirer;
+/// let answer = inquirer::input("What is the airspeed velocity of an unladen swallow?");
+/// ```
+///
+/// ## Error Handling
+///
+/// ```rust,no_run
+/// # extern crate inquirer;
+/// match inquirer::input("What is the airspeed velocity of an unladen swallow?") {
+///     Ok(result) => println!("You chose {:?}.", result),
+///     Err(inquirer::Error::UserAborted) => {
+///         println!("Pressed Ctrl-C, exiting.");
+///         std::process::exit(1);
+///     }
+///     Err(err) => println!("{:?}", err)
+/// }
+/// ```
+pub fn input(prompt: &str) -> Result<String, Error> {
+    let mut stdin = stdin();
+    let mut stdout = stdout();
+
+    try!(stdout.color(color::Green));
+    print!("[?] ");
+    try!(stdout.reset());
+    print!("{} ", prompt);
+
+    try!(stdout.lock().flush());
+
+    match TermRead::read_line(&mut stdin) {
+        Ok(Some(s)) => Ok(s),
+        Ok(None) => Err(Error::NoMoreInput),
+        Err(e) => Err(Error::Io(e)),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,10 @@ mod choice;
 mod error;
 mod list;
 mod confirm;
+mod input;
 
 pub use choice::Choice;
 pub use error::Error;
 pub use list::list;
 pub use confirm::confirm;
+pub use input::input;


### PR DESCRIPTION
This adds support for `input`, a simple text input prompt.

Please note that, right now `input` is inconsistent with the other methods, `list` and `choice`. Specifically, aborting (Ctrl-C) at the prompt, does not return Error::UserAborted, it simply terminates the program.

Ideally, we'd like the Ctrl+C behavior to be consistent across the different methods.
