### PR TITLE
Use upstream termion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ readme = "README.md"
 
 [dependencies]
 quick-error = "1.1.0"
-termion = { git = "https://github.com/Munksgaard/termion", branch = "add-controls" }
+termion = { git = "https://github.com/ticki/termion" }


### PR DESCRIPTION
Now that ticki/termion#27 has been merged, we can use the upstream termion repository instead of my local fork.
